### PR TITLE
Update workflow actions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -28,12 +28,12 @@ jobs:
         working-directory: ./src/D2Oracle
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: 'true'
     
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.x
     - name: Restore dependencies
@@ -45,7 +45,7 @@ jobs:
     - name: Publish
       run: dotnet publish D2Oracle.Avalonia/D2Oracle.Avalonia.csproj -r ${{ matrix.rid }} --self-contained true -c Release -o Release
     - name: Upload build
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: build-${{ matrix.rid }}
         path: ./src/D2Oracle/Release


### PR DESCRIPTION
Update action versions to v4 due to warning:

`Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-dotnet@v3, actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.`